### PR TITLE
Remove manual document checking from main journey

### DIFF
--- a/app/views/v2/candidate/webcam-photo-accepted.html
+++ b/app/views/v2/candidate/webcam-photo-accepted.html
@@ -11,7 +11,7 @@
 			
 			<h1 class="heading-xlarge">Now hand the device back to the hiring manager</h1>
 
-			<a href="../id_checker/post-candidate/id_check_guidance.html" class="button">Continue</a>
+			<a href="../id_checker/post-candidate/identity_verified" class="button">Continue</a>
 
     </div>
   </div>


### PR DESCRIPTION
Document checking is not needed when users successfully prove their identity with Verify, so this pull request removes that page from the main journey.

Fixes #13. 

## Before

`webcam-photo-accepted` -> `id_check_guidance` -> `identity_verified`

## After

`webcam-photo-accepted` -> `identity_verified`
